### PR TITLE
Max texture limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 
 _test/
 trenchbroom_example/autosave/
-addons/godot-git-plugin
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 _test/
 trenchbroom_example/autosave/
+addons/godot-git-plugin
+.DS_Store

--- a/addons/qmapbsp/importer/bsp_parser.gd
+++ b/addons/qmapbsp/importer/bsp_parser.gd
@@ -77,7 +77,7 @@ var entities : Array[Array]
 # Built-in BSP material
 var global_surface_mat : ShaderMaterial
 var global_textures : Array[Texture2D]
-const GLOBAL_TEXTURE_LIMIT := 256 # NOT AN ACTUAL LIMIT
+const GLOBAL_TEXTURE_LIMIT := 96 # device dependent
 
 var import_tasks := [
 	[_read_vertices, 128],
@@ -241,7 +241,7 @@ func _read_mip_textures() -> float :
 		if !mat :
 			if global_textures.size() > GLOBAL_TEXTURE_LIMIT :
 				# oof
-				printerr("You hit the texture limit ! (> 256)")
+				printerr("You hit the texture limit ! (> %d)" % GLOBAL_TEXTURE_LIMIT)
 			else :
 				texture_ids[load_index] = global_textures.size()
 				global_textures.append(tex)
@@ -660,6 +660,7 @@ func _build_geo() -> bool :
 		occ_indices = PackedInt32Array()
 		
 		if global_surface_mat :
+			global_textures.resize(GLOBAL_TEXTURE_LIMIT)
 			global_surface_mat.set_shader_parameter(&'texs', global_textures)
 			global_surface_mat.set_shader_parameter(&'lmp', lmtex)
 			

--- a/addons/qmapbsp/resource/shader/surface.gdshader
+++ b/addons/qmapbsp/resource/shader/surface.gdshader
@@ -4,7 +4,7 @@ render_mode unshaded;
 uniform int mode = 0;
 uniform float lmboost = 4.0;
 uniform bool regionhl = false;
-uniform sampler2D[256] texs : source_color; // not an actual limit
+uniform sampler2D[96] texs : source_color; // device dependent
 uniform sampler2D lmp : repeat_disable;
 uniform float[64] lightstyles;
 

--- a/addons/qmapbsp/resource/shader/surface_and_shade.gdshader
+++ b/addons/qmapbsp/resource/shader/surface_and_shade.gdshader
@@ -3,7 +3,7 @@ shader_type spatial;
 uniform int mode = 0;
 uniform float lmboost = 4.0;
 uniform bool regionhl = false;
-uniform sampler2D[256] texs : source_color; // not an actual limit
+uniform sampler2D[96] texs : source_color; // device dependent
 uniform sampler2D lmp : repeat_disable;
 uniform float[12] lightstyles;
 

--- a/addons/qmapbsp/resource/shader/surface_no_lightmap.gdshader
+++ b/addons/qmapbsp/resource/shader/surface_no_lightmap.gdshader
@@ -3,7 +3,7 @@ shader_type spatial;
 uniform int mode = 0;
 uniform float lmboost = 4.0;
 uniform bool regionhl = false;
-uniform sampler2D[256] texs : source_color; // not an actual limit
+uniform sampler2D[96] texs : source_color; // device dependent
 uniform sampler2D lmp : repeat_disable;
 uniform float[12] lightstyles;
 


### PR DESCRIPTION
### Why?
Texture sample numbers are device dependent, and the limit is smaller on M2 Macs, for compatibility purposes aiming for lower common denominator.

Also worth noting that it's probably worth exploring in the future using only one texture sampler as that's usually how shaders are implemented, one texture sampler per texture type. IE: albedo, metallic, normal, lightmap, etc...

### What?
* Set lower texture sampler count