### PR TITLE
Bug fix worldspawn config parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 
 _test/
 trenchbroom_example/autosave/
-addons/godot-git-plugin
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 _test/
 trenchbroom_example/autosave/
+addons/godot-git-plugin
+.DS_Store

--- a/addons/qmapbsp/importer/world_importer.gd
+++ b/addons/qmapbsp/importer/world_importer.gd
@@ -115,7 +115,12 @@ func _entity_your_properties(id : int, entity : Dictionary) -> void :
 ## Offers essential properties on each entity
 func _entity_your_cooked_properties(id : int, entity : Dictionary) -> void :
 	var classname : String = entity.get('classname', '')
-	if id != 0 :
+	if id == 0 : # worldspawn
+		entity['spawnflags'] = QmapbspMapFormat.expect_int(entity.get('spawnflags', ''))
+		entity['sounds'] = QmapbspMapFormat.expect_int(entity.get('sounds', ''))
+		entity['worldtype'] = QmapbspMapFormat.expect_int(entity.get('worldtype', ''))
+		entity['light'] = QmapbspMapFormat.expect_int(entity.get('light', ''))
+	else:
 		entity['origin'] = (
 			QmapbspBaseParser._qnor_to_vec3(
 				QmapbspMapFormat.expect_vec3(entity.get('origin', ''))
@@ -126,6 +131,7 @@ func _entity_your_cooked_properties(id : int, entity : Dictionary) -> void :
 		if angle >= 0 : angle += 90
 		entity['angle'] = angle
 		entity['spawnflags'] = QmapbspMapFormat.expect_int(entity.get('spawnflags', ''))
+		
 	
 #########################################
 

--- a/quake1_example/class/light.gd
+++ b/quake1_example/class/light.gd
@@ -10,8 +10,7 @@ func _init() :
 	#shadow_enabled = true
 	light_bake_mode = Light3D.BAKE_STATIC
 	
-	var s : String = props.get("light", "300")
-	var light := s.to_int()
+	var light : int = props.get("light", 300)
 	omni_range = light / 32.0
 	omni_attenuation = 0.00001
 	light_indirect_energy = light / 50.0

--- a/quake1_example/class/worldspawn.gd
+++ b/quake1_example/class/worldspawn.gd
@@ -30,7 +30,7 @@ func _init() -> void :
 func _map_ready() :
 	var viewer : QmapbspQuakeViewer = get_meta(&'viewer', null)
 	if viewer :
-		music.stream = viewer.get_music(props.get('sounds', '0').to_int())
+		music.stream = viewer.get_music(props.get('sounds', 0))
 		music.play()
 		
 		var env : Environment = wenv.environment


### PR DESCRIPTION
### Why?

When loading `dm_4` map, a spawnflag was of improper type, which caused a crash, this was due to worldspawn config values not being parsed into expected types

### What?

* Parsing worldspawn integer value types
* Some updates to code which expected stings, but are now getting correct int type values
* Fixes map load crash for `dm_4`