### PR TITLE
Add MDL support

### DIFF
--- a/quake1_example/README.md
+++ b/quake1_example/README.md
@@ -9,4 +9,4 @@ This viewer requires PAK files and **MAP files of maps** inside the PAK to load.
 Tested on some ID Software's Quake (Shareware) maps. Not all entities are implemented yet. And remember that you have to run this viewer on the full project. Because it contains bound keys for the player character.
 
 ## Usage
-Run `hub.tscn` then enter your Mod and MAP paths. And hit `Load`. The tree will display a file structure inside the PAK files. You can click on some resources to play (\*.bsp, \*.wav) or view (\*.wad, \*.lmp). MDL files are not supported yet
+Run `hub.tscn` then enter your Mod and MAP paths. And hit `Load`. The tree will display a file structure inside the PAK files. You can click on some resources to play (\*.bsp, \*.wav) or view (\*.wad, \*.lmp).

--- a/quake1_example/class/light_flame_large_yellow.gd
+++ b/quake1_example/class/light_flame_large_yellow.gd
@@ -1,9 +1,9 @@
 extends QmapbspQuakeLight
-class_name QmapbspQuakeLightTorchSmallWalltorch
+class_name QmapbspQuakeLightFlameLargeYellow
 
 func _map_ready() -> void :
 	var viewer : QmapbspQuakeViewer = get_meta(&'viewer')
-	var mdl : QmapbspMDLFile = viewer.hub.load_model("progs/flame.mdl")
+	var mdl : QmapbspMDLFile = viewer.hub.load_model("progs/flame2.mdl")
 	var mdli := QmapbspMDLInstance.new()
 	mdli.mdl = mdl
 	mdli.name = &"MODEL"

--- a/quake1_example/hub.tscn
+++ b/quake1_example/hub.tscn
@@ -1,8 +1,87 @@
-[gd_scene load_steps=4 format=3 uid="uid://b4fsmrslaowwn"]
+[gd_scene load_steps=12 format=3 uid="uid://b4fsmrslaowwn"]
 
 [ext_resource type="Script" path="res://quake1_example/quake1_hub.gd" id="1_2c1wm"]
 [ext_resource type="Texture2D" uid="uid://dwa5a34uawid4" path="res://quake1_example/background.png" id="1_q0fs5"]
 [ext_resource type="Texture2D" uid="uid://ddgo0qldm1jtp" path="res://icon.svg" id="2_c3pq6"]
+[ext_resource type="Script" path="res://quake1_example/mdl_instance.gd" id="4_q5pgd"]
+
+[sub_resource type="Environment" id="Environment_8m3j4"]
+ambient_light_color = Color(0.72549, 0.282353, 0.0784314, 1)
+
+[sub_resource type="Animation" id="Animation_v10ej"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("root/mesh:seek")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+
+[sub_resource type="Animation" id="Animation_dc32k"]
+resource_name = "seekloop"
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("root/mesh:seek")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_eflf5"]
+_data = {
+"RESET": SubResource("Animation_v10ej"),
+"seekloop": SubResource("Animation_dc32k")
+}
+
+[sub_resource type="Animation" id="Animation_dy4w6"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("root/mesh:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_flwlq"]
+resource_name = "spin"
+length = 2.0
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("root/mesh:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(0, 6.28319, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_iedm2"]
+_data = {
+"RESET": SubResource("Animation_dy4w6"),
+"spin": SubResource("Animation_flwlq")
+}
 
 [node name="hub" type="Control"]
 layout_mode = 3
@@ -119,23 +198,77 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 hide_root = true
 
-[node name="texview" type="VBoxContainer" parent="tabs/PAK Viewer/vbox/hbox3"]
-visible = false
+[node name="view" type="Control" parent="tabs/PAK Viewer/vbox/hbox3"]
 layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="texview" type="VBoxContainer" parent="tabs/PAK Viewer/vbox/hbox3/view"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.5
 
-[node name="tex" type="TextureRect" parent="tabs/PAK Viewer/vbox/hbox3/texview"]
+[node name="tex" type="TextureRect" parent="tabs/PAK Viewer/vbox/hbox3/view/texview"]
 layout_mode = 2
 size_flags_vertical = 3
 texture = ExtResource("2_c3pq6")
 expand_mode = 1
 stretch_mode = 5
 
-[node name="info" type="Label" parent="tabs/PAK Viewer/vbox/hbox3/texview"]
+[node name="info" type="Label" parent="tabs/PAK Viewer/vbox/hbox3/view/texview"]
 layout_mode = 2
 text = "Select an LMP or WAD entry file to view a texture !"
 autowrap_mode = 2
+
+[node name="mdlview" type="VBoxContainer" parent="tabs/PAK Viewer/vbox/hbox3/view"]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="vc" type="SubViewportContainer" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview"]
+layout_mode = 2
+size_flags_vertical = 3
+stretch = true
+
+[node name="vp" type="SubViewport" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc"]
+handle_input_locally = false
+size = Vector2i(2, 2)
+render_target_update_mode = 0
+
+[node name="root" type="Node3D" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp"]
+
+[node name="mesh" type="MeshInstance3D" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp/root"]
+transform = Transform3D(0.031, 0, 0, 0, 0.031, 0, 0, 0, 0.031, 0, 0, 0)
+script = ExtResource("4_q5pgd")
+
+[node name="cam3d" type="Camera3D" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp/root"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4)
+environment = SubResource("Environment_8m3j4")
+current = true
+
+[node name="light" type="DirectionalLight3D" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp/root"]
+transform = Transform3D(1, 0, 0, 0, 0.5, 0.866025, 0, -0.866025, 0.5, 0, 0, 0)
+
+[node name="animesh" type="AnimationPlayer" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp"]
+unique_name_in_owner = true
+speed_scale = 0.1
+libraries = {
+"": SubResource("AnimationLibrary_eflf5")
+}
+
+[node name="anispin" type="AnimationPlayer" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp"]
+unique_name_in_owner = true
+libraries = {
+"": SubResource("AnimationLibrary_iedm2")
+}
 
 [node name="status" type="Label" parent="tabs/PAK Viewer/vbox"]
 layout_mode = 2

--- a/quake1_example/hub.tscn
+++ b/quake1_example/hub.tscn
@@ -250,9 +250,11 @@ transform = Transform3D(0.031, 0, 0, 0, 0.031, 0, 0, 0, 0.031, 0, 0, 0)
 script = ExtResource("4_q5pgd")
 
 [node name="cam3d" type="Camera3D" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp/root"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.125)
 environment = SubResource("Environment_8m3j4")
 current = true
+near = 0.001
+far = 32.0
 
 [node name="light" type="DirectionalLight3D" parent="tabs/PAK Viewer/vbox/hbox3/view/mdlview/vc/vp/root"]
 transform = Transform3D(1, 0, 0, 0, 0.5, 0.866025, 0, -0.866025, 0.5, 0, 0, 0)

--- a/quake1_example/material/fluid.gdshader
+++ b/quake1_example/material/fluid.gdshader
@@ -1,5 +1,5 @@
 shader_type spatial;
-render_mode unshaded, shadows_disabled, depth_prepass_alpha;
+render_mode unshaded, shadows_disabled, depth_prepass_alpha, specular_disabled;
 
 uniform sampler2D tex : source_color;
 uniform float alpha = 0.8;

--- a/quake1_example/material/mdl_animated.gdshader
+++ b/quake1_example/material/mdl_animated.gdshader
@@ -1,0 +1,23 @@
+shader_type spatial;
+render_mode specular_disabled;
+
+uniform sampler2D skin : source_color;
+
+uniform sampler2D animation;
+uniform vec3 scale;
+uniform vec3 origin;
+uniform float seek;
+
+void vertex() {
+	vec2 pixhalf = 1.0 / vec2(textureSize(animation, 0)) * 0.5f;
+	vec3 v = vec3(
+		255.0f * texture(animation, vec2(CUSTOM0.x, seek) + pixhalf).xyz
+	) * scale + origin;
+	VERTEX = vec3(-v.x, v.z, v.y);
+}
+
+void fragment() {
+	ROUGHNESS = 1.0f;
+	METALLIC = 0.0f;
+	ALBEDO.rgb = texture(skin, UV).rgb;
+}

--- a/quake1_example/mdl.gd
+++ b/quake1_example/mdl.gd
@@ -1,10 +1,6 @@
 extends Resource
 class_name QmapbspMDLFile
 
-## ded file
-
-var scale : Vector3
-var origin : Vector3
 var radius : float
 var offsets : Vector3
 
@@ -27,10 +23,10 @@ static func load_from_file(f : FileAccess, pal_ : PackedColorArray) :
 	
 	var mdl := QmapbspMDLFile.new()
 	mdl.pal = pal_
-	mdl.scale = QmapbspBaseParser._qnor_to_vec3_read(f)
-	mdl.origin = QmapbspBaseParser._qnor_to_vec3_read(f)
+	mdl.quake_scale = QmapbspBaseParser._read_vec3(f)
+	mdl.quake_origin = QmapbspBaseParser._read_vec3(f)
 	mdl.radius = f.get_float()
-	mdl.offsets = QmapbspBaseParser._qnor_to_vec3_read(f)
+	mdl.offsets = QmapbspBaseParser._read_vec3(f)
 	
 	mdl.numskins = f.get_32()
 	mdl.skinwidth = f.get_32()
@@ -43,6 +39,9 @@ static func load_from_file(f : FileAccess, pal_ : PackedColorArray) :
 	mdl.size = f.get_float()
 	
 	mdl.load(f)
+	mdl.make_base_model()
+	mdl.bake_animations()
+	mdl.clean()
 	
 	return mdl
 
@@ -52,29 +51,154 @@ var skinvertices : PackedVector3Array
 var triangles : PackedColorArray
 var frames : Array[Array]
 
+#############
+
+@export var base_mesh : ArrayMesh
+@export var quake_scale : Vector3
+@export var quake_origin : Vector3
+@export var animation : ImageTexture
+@export var skin : ImageTexture
+
+const UUU := 0.0
+func make_base_model() -> void :
+	var st := SurfaceTool.new()
+	var skinarr : Array = skins[0]
+	var im : Image
+	if skinarr[0] == 0 :
+		im = skinarr[1]
+	else :
+		im = skinarr[-1][0]
+	skin = ImageTexture.create_from_image(im)
+	
+	st.begin(Mesh.PRIMITIVE_TRIANGLES)
+	st.set_custom_format(0, SurfaceTool.CUSTOM_R_FLOAT)
+	
+	for t in triangles :
+		var v := Vector3i(
+			t[1], t[2], t[3]
+		)
+		var s0 := skinvertices[v[0]]
+		var s1 := skinvertices[v[1]]
+		var s2 := skinvertices[v[2]]
+		if int(t[0]) == 0 : # front
+			if int(s0[0]) == 0x20 and s0[1] <= 0.5 : s0[1] += 0.5
+			if int(s1[0]) == 0x20 and s1[1] <= 0.5 : s1[1] += 0.5
+			if int(s2[0]) == 0x20 and s2[1] <= 0.5 : s2[1] += 0.5
+		else :
+			if int(s0[0]) == 0x20 and s0[1] >= 0.5 : s0[1] -= 0.5
+			if int(s1[0]) == 0x20 and s1[1] >= 0.5 : s1[1] -= 0.5
+			if int(s2[0]) == 0x20 and s2[1] >= 0.5 : s2[1] -= 0.5
+		
+		
+		var first_frame : Array[PackedByteArray]
+		if frames[0][0] == 0 :
+			first_frame = frames[0][-1][3]
+		else :
+			first_frame = frames[0][-1][0][3]
+		
+		var first_frame_verts : PackedByteArray = first_frame[v[0]]
+		st.set_uv(Vector2(s0[1] , s0[2]))
+		st.set_normal(QmapbspBaseParser._qnor_to_vec3(NORMS[first_frame_verts[3]]))
+		st.set_custom(0, Color(v[0] / float(numverts), UUU, UUU))
+		st.add_vertex(QmapbspBaseParser._qnor_to_vec3(Vector3(
+			first_frame_verts[0],
+			first_frame_verts[1],
+			first_frame_verts[2]
+		) * quake_scale + quake_origin))
+		first_frame_verts = first_frame[v[1]]
+		st.set_uv(Vector2(s1[1], s1[2]))
+		st.set_normal(QmapbspBaseParser._qnor_to_vec3(NORMS[first_frame_verts[3]]))
+		st.set_custom(0, Color(v[1] / float(numverts), UUU, UUU))
+		st.add_vertex(QmapbspBaseParser._qnor_to_vec3(Vector3(
+			first_frame_verts[0],
+			first_frame_verts[1],
+			first_frame_verts[2]
+		) * quake_scale + quake_origin))
+		first_frame_verts = first_frame[v[2]]
+		st.set_uv(Vector2(s2[1], s2[2]))
+		st.set_normal(QmapbspBaseParser._qnor_to_vec3(NORMS[first_frame_verts[3]]))
+		st.set_custom(0, Color(v[2] / float(numverts), UUU, UUU))
+		st.add_vertex(QmapbspBaseParser._qnor_to_vec3(Vector3(
+			first_frame_verts[0],
+			first_frame_verts[1],
+			first_frame_verts[2]
+		) * quake_scale + quake_origin))
+		
+	base_mesh = st.commit()
+	#print(scale)
+	#print(origin)
+	#ResourceSaver.save(base_mesh, "res://a.mesh")
+
+func bake_animations() -> void :
+	var im := Image.create(numverts, numframes, false, Image.FORMAT_RGB8)
+	for f in numframes :
+		var simpleframe : Array = frames[f][-1]
+		
+		var vertices : Array[PackedByteArray]
+		if frames[f][0] == 0 :
+			vertices = simpleframe[3]
+		else :
+			vertices = simpleframe[0][3]
+		
+		for i in vertices.size() :
+			var V := vertices[i]
+			var v := Vector3(
+				V[0], V[1], V[2]
+			) / 255
+			im.set_pixel(i, f, Color(
+				v.x, v.y, v.z
+			))
+	animation = ImageTexture.create_from_image(im)
+
+func clean() -> void :
+	pal = PackedColorArray()
+	skins.clear()
+	skinvertices.clear()
+	triangles.clear()
+	frames.clear()
+
 func load(f : FileAccess) :
 	# skins
 	skins.resize(numskins)
 	
-	var image := QmapbspPakFile._make_image([
-		Vector2i(skinwidth, skinheight),
-		f.get_buffer(skinwidth * skinheight)
-	], pal)
-	
-	var g : int = f.get_32()
 	for i in numskins :
-		skins[i] = [
-			g,
-			image
-		]
+		if f.get_32() == 0 :
+			skins[i] = [
+				0,
+				QmapbspPakFile._make_image([
+					Vector2i(skinwidth, skinheight),
+					f.get_buffer(skinwidth * skinheight)
+				], pal)
+			]
+		else :
+			var nb := f.get_32()
+			skins[i] = [
+				nb,
+				(
+					func() :
+						var pf32 : PackedFloat32Array
+						pf32.resize(nb)
+						for j in nb : pf32[j] = f.get_32()
+						return pf32
+						).call(),
+				(
+					func() :
+						var iarr : Array[Image]
+						for j in nb : iarr[j] = QmapbspPakFile._make_image([
+							Vector2i(skinwidth, skinheight),
+							f.get_buffer(skinwidth * skinheight)
+						], pal)
+						return iarr
+						).call()
+			]
 		
 	# skinvertices
 	skinvertices.resize(numverts)
 	for i in numverts :
 		skinvertices[i] = Vector3(
 			f.get_32(),
-			f.get_32(),
-			f.get_32()
+			float(f.get_32()) / skinwidth,
+			float(f.get_32()) / skinheight
 		)
 		
 	# tris
@@ -87,36 +211,223 @@ func load(f : FileAccess) :
 			f.get_32()
 		)
 		
-#	# frames
-#	frames.resize(numframes)
-#	for i in numframes :
-#		if f.get_32() == 0 :
-#			numframes[i] = [_get_simpleframe_t]
-#		else :
-#			numframes[i] = [
-#				_get_trivertx_t(f),
-#				_get_trivertx_t(f),
-#				func() :
-#					var arr : PackedFloat32Array
-#					arr.resize(numverts)
-#					for i in numverts :
-#						arr[i] = _get_trivertx_t(f)
-#					return arr
-#				[_get_simpleframe_t]
-#			]
+	# frames
+	frames.resize(numframes)
+	for i in numframes :
+		var type := f.get_32()
+		if type == 0 :
+			frames[i] = [
+				# single
+				type,
+				_get_simpleframe_t(f)
+			]
+		else :
+			var nb := f.get_32()
+			frames[i] = [
+				# group
+				type,
+				nb, # nb
+				_get_trivertx_t(f), # min
+				_get_trivertx_t(f), # max
+				
+				(
+					func() :
+						var pf32 : PackedFloat32Array
+						pf32.resize(nb)
+						for j in nb : pf32[j] = f.get_32()
+						return pf32
+						).call(),
+				(
+					func() :
+						var simpleframes : Array[Array]
+						simpleframes.resize(nb)
+						for j in nb : simpleframes[j] = _get_simpleframe_t(f)
+						return simpleframes
+						).call(),
+				
+			]
+	pass
 			
-func _get_simpleframe_t(f : FileAccess) -> PackedByteArray :
+func _get_simpleframe_t(f : FileAccess) -> Array :
 	return [
 		_get_trivertx_t(f),
 		_get_trivertx_t(f),
 		f.get_buffer(16).get_string_from_ascii(),
-		func() :
-			var arr : Array
-			arr.resize(numverts)
-			for i in numverts :
-				arr[i] = _get_trivertx_t(f)
-			return arr
+		(
+			func() :
+				var arr : Array[PackedByteArray]
+				arr.resize(numverts)
+				for i in numverts :
+					arr[i] = _get_trivertx_t(f)
+				return arr
+				).call()
 	]
 
 func _get_trivertx_t(f : FileAccess) -> PackedByteArray :
 	return f.get_buffer(4)
+
+# 162 precalculated normals
+const NORMS : PackedVector3Array = [
+	Vector3(-0.525731, 0.000000, 0.850651),
+	Vector3(-0.442863, 0.238856, 0.864188),
+	Vector3(-0.295242, 0.000000, 0.955423),
+	Vector3(-0.309017, 0.500000, 0.809017),
+	Vector3(-0.162460, 0.262866, 0.951056),
+	Vector3(0.000000, 0.000000, 1.000000),
+	Vector3(0.000000, 0.850651, 0.525731),
+	Vector3(-0.147621, 0.716567, 0.681718),
+	Vector3(0.147621, 0.716567, 0.681718),
+	Vector3(0.000000, 0.525731, 0.850651),
+	Vector3(0.309017, 0.500000, 0.809017),
+	Vector3(0.525731, 0.000000, 0.850651),
+	Vector3(0.295242, 0.000000, 0.955423),
+	Vector3(0.442863, 0.238856, 0.864188),
+	Vector3(0.162460, 0.262866, 0.951056),
+	Vector3(-0.681718, 0.147621, 0.716567),
+	Vector3(-0.809017, 0.309017, 0.500000),
+	Vector3(-0.587785, 0.425325, 0.688191),
+	Vector3(-0.850651, 0.525731, 0.000000),
+	Vector3(-0.864188, 0.442863, 0.238856),
+	Vector3(-0.716567, 0.681718, 0.147621),
+	Vector3(-0.688191, 0.587785, 0.425325),
+	Vector3(-0.500000, 0.809017, 0.309017),
+	Vector3(-0.238856, 0.864188, 0.442863),
+	Vector3(-0.425325, 0.688191, 0.587785),
+	Vector3(-0.716567, 0.681718, -0.147621),
+	Vector3(-0.500000, 0.809017, -0.309017),
+	Vector3(-0.525731, 0.850651, 0.000000),
+	Vector3(0.000000, 0.850651, -0.525731),
+	Vector3(-0.238856, 0.864188, -0.442863),
+	Vector3(0.000000, 0.955423, -0.295242),
+	Vector3(-0.262866, 0.951056, -0.162460),
+	Vector3(0.000000, 1.000000, 0.000000),
+	Vector3(0.000000, 0.955423, 0.295242),
+	Vector3(-0.262866, 0.951056, 0.162460),
+	Vector3(0.238856, 0.864188, 0.442863),
+	Vector3(0.262866, 0.951056, 0.162460),
+	Vector3(0.500000, 0.809017, 0.309017),
+	Vector3(0.238856, 0.864188, -0.442863),
+	Vector3(0.262866, 0.951056, -0.162460),
+	Vector3(0.500000, 0.809017, -0.309017),
+	Vector3(0.850651, 0.525731, 0.000000),
+	Vector3(0.716567, 0.681718, 0.147621),
+	Vector3(0.716567, 0.681718, -0.147621),
+	Vector3(0.525731, 0.850651, 0.000000),
+	Vector3(0.425325, 0.688191, 0.587785),
+	Vector3(0.864188, 0.442863, 0.238856),
+	Vector3(0.688191, 0.587785, 0.425325),
+	Vector3(0.809017, 0.309017, 0.500000),
+	Vector3(0.681718, 0.147621, 0.716567),
+	Vector3(0.587785, 0.425325, 0.688191),
+	Vector3(0.955423, 0.295242, 0.000000),
+	Vector3(1.000000, 0.000000, 0.000000),
+	Vector3(0.951056, 0.162460, 0.262866),
+	Vector3(0.850651, -0.525731, 0.000000),
+	Vector3(0.955423, -0.295242, 0.000000),
+	Vector3(0.864188, -0.442863, 0.238856),
+	Vector3(0.951056, -0.162460, 0.262866),
+	Vector3(0.809017, -0.309017, 0.500000),
+	Vector3(0.681718, -0.147621, 0.716567),
+	Vector3(0.850651, 0.000000, 0.525731),
+	Vector3(0.864188, 0.442863, -0.238856),
+	Vector3(0.809017, 0.309017, -0.500000),
+	Vector3(0.951056, 0.162460, -0.262866),
+	Vector3(0.525731, 0.000000, -0.850651),
+	Vector3(0.681718, 0.147621, -0.716567),
+	Vector3(0.681718, -0.147621, -0.716567),
+	Vector3(0.850651, 0.000000, -0.525731),
+	Vector3(0.809017, -0.309017, -0.500000),
+	Vector3(0.864188, -0.442863, -0.238856),
+	Vector3(0.951056, -0.162460, -0.262866),
+	Vector3(0.147621, 0.716567, -0.681718),
+	Vector3(0.309017, 0.500000, -0.809017),
+	Vector3(0.425325, 0.688191, -0.587785),
+	Vector3(0.442863, 0.238856, -0.864188),
+	Vector3(0.587785, 0.425325, -0.688191),
+	Vector3(0.688191, 0.587785, -0.425325),
+	Vector3(-0.147621, 0.716567, -0.681718),
+	Vector3(-0.309017, 0.500000, -0.809017),
+	Vector3(0.000000, 0.525731, -0.850651),
+	Vector3(-0.525731, 0.000000, -0.850651),
+	Vector3(-0.442863, 0.238856, -0.864188),
+	Vector3(-0.295242, 0.000000, -0.955423),
+	Vector3(-0.162460, 0.262866, -0.951056),
+	Vector3(0.000000, 0.000000, -1.000000),
+	Vector3(0.295242, 0.000000, -0.955423),
+	Vector3(0.162460, 0.262866, -0.951056),
+	Vector3(-0.442863, -0.238856, -0.864188),
+	Vector3(-0.309017, -0.500000, -0.809017),
+	Vector3(-0.162460, -0.262866, -0.951056),
+	Vector3(0.000000, -0.850651, -0.525731),
+	Vector3(-0.147621, -0.716567, -0.681718),
+	Vector3(0.147621, -0.716567, -0.681718),
+	Vector3(0.000000, -0.525731, -0.850651),
+	Vector3(0.309017, -0.500000, -0.809017),
+	Vector3(0.442863, -0.238856, -0.864188),
+	Vector3(0.162460, -0.262866, -0.951056),
+	Vector3(0.238856, -0.864188, -0.442863),
+	Vector3(0.500000, -0.809017, -0.309017),
+	Vector3(0.425325, -0.688191, -0.587785),
+	Vector3(0.716567, -0.681718, -0.147621),
+	Vector3(0.688191, -0.587785, -0.425325),
+	Vector3(0.587785, -0.425325, -0.688191),
+	Vector3(0.000000, -0.955423, -0.295242),
+	Vector3(0.000000, -1.000000, 0.000000),
+	Vector3(0.262866, -0.951056, -0.162460),
+	Vector3(0.000000, -0.850651, 0.525731),
+	Vector3(0.000000, -0.955423, 0.295242),
+	Vector3(0.238856, -0.864188, 0.442863),
+	Vector3(0.262866, -0.951056, 0.162460),
+	Vector3(0.500000, -0.809017, 0.309017),
+	Vector3(0.716567, -0.681718, 0.147621),
+	Vector3(0.525731, -0.850651, 0.000000),
+	Vector3(-0.238856, -0.864188, -0.442863),
+	Vector3(-0.500000, -0.809017, -0.309017),
+	Vector3(-0.262866, -0.951056, -0.162460),
+	Vector3(-0.850651, -0.525731, 0.000000),
+	Vector3(-0.716567, -0.681718, -0.147621),
+	Vector3(-0.716567, -0.681718, 0.147621),
+	Vector3(-0.525731, -0.850651, 0.000000),
+	Vector3(-0.500000, -0.809017, 0.309017),
+	Vector3(-0.238856, -0.864188, 0.442863),
+	Vector3(-0.262866, -0.951056, 0.162460),
+	Vector3(-0.864188, -0.442863, 0.238856),
+	Vector3(-0.809017, -0.309017, 0.500000),
+	Vector3(-0.688191, -0.587785, 0.425325),
+	Vector3(-0.681718, -0.147621, 0.716567),
+	Vector3(-0.442863, -0.238856, 0.864188),
+	Vector3(-0.587785, -0.425325, 0.688191),
+	Vector3(-0.309017, -0.500000, 0.809017),
+	Vector3(-0.147621, -0.716567, 0.681718),
+	Vector3(-0.425325, -0.688191, 0.587785),
+	Vector3(-0.162460, -0.262866, 0.951056),
+	Vector3(0.442863, -0.238856, 0.864188),
+	Vector3(0.162460, -0.262866, 0.951056),
+	Vector3(0.309017, -0.500000, 0.809017),
+	Vector3(0.147621, -0.716567, 0.681718),
+	Vector3(0.000000, -0.525731, 0.850651),
+	Vector3(0.425325, -0.688191, 0.587785),
+	Vector3(0.587785, -0.425325, 0.688191),
+	Vector3(0.688191, -0.587785, 0.425325),
+	Vector3(-0.955423, 0.295242, 0.000000),
+	Vector3(-0.951056, 0.162460, 0.262866),
+	Vector3(-1.000000, 0.000000, 0.000000),
+	Vector3(-0.850651, 0.000000, 0.525731),
+	Vector3(-0.955423, -0.295242, 0.000000),
+	Vector3(-0.951056, -0.162460, 0.262866),
+	Vector3(-0.864188, 0.442863, -0.238856),
+	Vector3(-0.951056, 0.162460, -0.262866),
+	Vector3(-0.809017, 0.309017, -0.500000),
+	Vector3(-0.864188, -0.442863, -0.238856),
+	Vector3(-0.951056, -0.162460, -0.262866),
+	Vector3(-0.809017, -0.309017, -0.500000),
+	Vector3(-0.681718, 0.147621, -0.716567),
+	Vector3(-0.681718, -0.147621, -0.716567),
+	Vector3(-0.850651, 0.000000, -0.525731),
+	Vector3(-0.688191, 0.587785, -0.425325),
+	Vector3(-0.587785, 0.425325, -0.688191),
+	Vector3(-0.425325, 0.688191, -0.587785),
+	Vector3(-0.425325, -0.688191, -0.587785),
+	Vector3(-0.587785, -0.425325, -0.688191),
+	Vector3(-0.688191, -0.587785, -0.425325)
+]

--- a/quake1_example/mdl.gd
+++ b/quake1_example/mdl.gd
@@ -14,7 +14,10 @@ var synctype : int
 var flags : int
 var size : float
 
-static func load_from_file(f : FileAccess, pal_ : PackedColorArray) :
+static func load_from_file(
+	f : FileAccess, pal_ : PackedColorArray,
+	inverse_scale_factor := 32.0
+) :
 	# HEADER
 	var begin := f.get_position()
 	if f.get_32() != 0x4F504449 : return &"MDL_INVALID_MAGIC"
@@ -23,8 +26,8 @@ static func load_from_file(f : FileAccess, pal_ : PackedColorArray) :
 	
 	var mdl := QmapbspMDLFile.new()
 	mdl.pal = pal_
-	mdl.quake_scale = QmapbspBaseParser._read_vec3(f)
-	mdl.quake_origin = QmapbspBaseParser._read_vec3(f)
+	mdl.quake_scale = QmapbspBaseParser._read_vec3(f) / inverse_scale_factor
+	mdl.quake_origin = QmapbspBaseParser._read_vec3(f) / inverse_scale_factor
 	mdl.radius = f.get_float()
 	mdl.offsets = QmapbspBaseParser._read_vec3(f)
 	

--- a/quake1_example/mdl_instance.gd
+++ b/quake1_example/mdl_instance.gd
@@ -1,0 +1,34 @@
+extends MeshInstance3D
+class_name QmapbspMDLInstance
+
+var mat : ShaderMaterial
+
+@export var mdl : QmapbspMDLFile :
+	set(v) :
+		if mdl == v : return
+		if mdl :
+			mesh.surface_set_material(0, null)
+		mdl = v
+		mesh = v.base_mesh
+		
+		if !mat :
+			mat = ShaderMaterial.new()
+			mat.shader = preload("res://quake1_example/material/mdl_animated.gdshader")
+		mesh.surface_set_material(0, mat)
+		
+		mat.set_shader_parameter(&'skin', v.skin)
+		mat.set_shader_parameter(&'scale', v.quake_scale)
+		mat.set_shader_parameter(&'origin', v.quake_origin)
+		mat.set_shader_parameter(&'animation', v.animation)
+		mat.set_shader_parameter(&'skin', v.skin)
+		
+		mat.set_shader_parameter(&'seek', seek)
+		
+@export var seek : float :
+	set(v) :
+		if mat :
+			mat.set_shader_parameter(&'seek', v)
+		seek = v
+
+func _init() -> void :
+	pass

--- a/quake1_example/quake1_hub.gd
+++ b/quake1_example/quake1_hub.gd
@@ -245,6 +245,15 @@ func load_as_texture(pakpath : String) -> ImageTexture :
 		c_textures[pakpath] = itex
 	return itex
 
+func load_model(p : String) -> QmapbspMDLFile :
+	var mdl : QmapbspMDLFile = loaded_models.get(p)
+	if !mdl :
+		mdl = QmapbspMDLFile.load_from_file(
+			FileAccess.open("user://packcache/".path_join(p), FileAccess.READ),
+			global_pal
+		)
+		loaded_models[p] = mdl
+	return mdl
 
 func _on_bsponly_toggled(yes : bool) :
 	texview_root.visible = !yes
@@ -288,13 +297,7 @@ func _on_tree_item_selected() -> void :
 			
 var loaded_models : Dictionary # <path : QmapbspMDLFile>
 func _show_mdl(p : String) -> void :
-	var mdl : QmapbspMDLFile = loaded_models.get(p)
-	if !mdl :
-		mdl = QmapbspMDLFile.load_from_file(
-			FileAccess.open("user://packcache/".path_join(p), FileAccess.READ),
-			global_pal
-		)
-		loaded_models[p] = mdl
+	var mdl : QmapbspMDLFile = load_model(p)
 	current_mdl.mdl = mdl
 	%animesh.play(&'seekloop')
 	%anispin.play(&'spin')


### PR DESCRIPTION
Add support for importing and rendering alias models (.mdl) to Godot mesh and vertex animation interpolation via shader (using VAT technique)

![image](https://github.com/gongpha/gdQmapbsp/assets/13400398/94358ec8-ebbd-49dd-8b3b-c0bf97812f97)
