### PR TITLE
Change conversion from X -> -X to X -> -Z

### DIFF
--- a/addons/qmapbsp/importer/base_parser.gd
+++ b/addons/qmapbsp/importer/base_parser.gd
@@ -111,7 +111,7 @@ func __sections__() -> Dictionary :
 	}
 
 static func _qnor_to_vec3(q : Vector3) -> Vector3 :
-	return Vector3(-q.x, q.z, q.y)
+	return Vector3(-q.y, q.z, -q.x)
 	
 static func _read_vec3(f : FileAccess) -> Vector3 :
 	return Vector3(

--- a/addons/qmapbsp/importer/map_parser.gd
+++ b/addons/qmapbsp/importer/map_parser.gd
@@ -97,13 +97,17 @@ func _parse_shape() -> void :
 		else :
 			var vertices := planes_intersect(planes)
 			var vs := vertices.size()
+			aabb.size = Vector3.ZERO
 			
 			for i in vs :
 				var v := vertices[i]
 				v = _qpos_to_vec3(v * -1)
 				vertices[i] = v
-				V += v
-			V /= vs
+				if i == 0 :
+					aabb.position = v
+				else :
+					aabb = aabb.expand(v)
+			V = aabb.get_center()
 			for i in vs :
 				vertices[i] -= V
 			

--- a/addons/qmapbsp/importer/world_importer.gd
+++ b/addons/qmapbsp/importer/world_importer.gd
@@ -136,9 +136,7 @@ func _entity_your_cooked_properties(id : int, entity : Dictionary) -> void :
 				/ _get_unit_scale_f()
 			)
 		)
-		var angle : int = QmapbspMapFormat.expect_int(entity.get('angle', ''))
-		if angle >= 0 : angle += 90
-		entity['angle'] = angle
+		entity['angle'] = QmapbspMapFormat.expect_int(entity.get('angle', ''))
 		entity['spawnflags'] = QmapbspMapFormat.expect_int(entity.get('spawnflags', ''))
 		
 	

--- a/quake1_example/class/func_door.gd
+++ b/quake1_example/class/func_door.gd
@@ -99,7 +99,7 @@ func _calc_add() :
 				aabb.size.x, 0.0, aabb.size.z
 			)) + Vector3(lip, 0.0, lip)
 			add = Vector3.BACK.rotated(Vector3.UP, rot) * dir
-			add_reveal = Vector3.RIGHT.rotated(Vector3.UP, -rot) * -(Vector3(
+			add_reveal = Vector3.LEFT.rotated(Vector3.UP, -rot) * -(Vector3(
 				aabb.size.x, 0.0, aabb.size.z
 			))
 		dura = add.length() / (props.get('speed', _def_speed()).to_int() / s)

--- a/quake1_example/class/func_train.gd
+++ b/quake1_example/class/func_train.gd
@@ -40,8 +40,8 @@ func _after_map_ready() :
 		_gen_aabb()
 		if curve and curve.point_count > 0 :
 			corner = aabb.size / 2.0
-			corner.x = -corner.x
-			position = curve.get_point_position(0) + corner
+			corner.y -= aabb.size.y
+			position = curve.get_point_position(0) - corner
 
 func _trigger(b : Node3D) :
 	if curve == null : return
@@ -62,7 +62,7 @@ func _start(c : Curve3D) :
 		) / (props.get('speed', '64').to_int() / s)
 		poscursor = nextpos
 		tween.tween_property(self, ^'position',
-			nextpos + corner,
+			nextpos - corner,
 			dura
 		)
 	player_end = false


### PR DESCRIPTION
Related to #31. Just change the coordinate conversion from `-x, z, y` to `-y, z, -x`.

Makes more sense than the old one because Godot uses -Z as the forward direction. The old conversion uses -X as the forward (same as Quake but in negative) and needs to rotate to -Z. But the new conversion uses -Z as the forward direction directly, no need to rotate.